### PR TITLE
Definindo onNoteDeleted como propriedade somente de leitura.

### DIFF
--- a/NOTES/src/components/note-card.tsx
+++ b/NOTES/src/components/note-card.tsx
@@ -10,7 +10,7 @@ interface NoteCardProps {
     date: Date
     content: string
   }
-  onNoteDeleted: (id: string) => void
+  readonly onNoteDeleted: (id: string) => void
 }
 
 export function NoteCard({ note, onNoteDeleted }: NoteCardProps){


### PR DESCRIPTION
Definindo onNoteDeleted como propriedade somente de leitura, tinha faltado no commit anterior 😅